### PR TITLE
[iOS] fix: 상세 스코어 화면의 선수별 점수표를 스크롤 할 때 가장 아래쪽의 셀이 재사용되면 폰트들이 bold 로 유…

### DIFF
--- a/iOS/BaseBall/BaseBall/Extension/UILabel+bold.swift
+++ b/iOS/BaseBall/BaseBall/Extension/UILabel+bold.swift
@@ -12,4 +12,8 @@ extension UILabel {
     func bold() {
         self.font = .boldSystemFont(ofSize: self.font.pointSize)
     }
+    
+    func normal() {
+        self.font = .systemFont(ofSize: self.font.pointSize)
+    }
 }

--- a/iOS/BaseBall/BaseBall/Score/ScoreCell.swift
+++ b/iOS/BaseBall/BaseBall/Score/ScoreCell.swift
@@ -31,9 +31,14 @@ class ScoreCell: UITableViewCell {
     
     func setValues(name: String, bat: String, hit: String, out: String, average: String) {
         playerNameLabel.text = name
+        playerNameLabel.normal()
         batLabel.text = bat
+        batLabel.normal()
         hitLabel.text = hit
+        hitLabel.normal()
         outLabel.text = out
+        outLabel.normal()
         averageLabel.text = average
+        averageLabel.isHidden = false
     }
 }


### PR DESCRIPTION
…지된 채로 재사용되는 문제

셀이 재사용 될 때 label 들의 폰트를 normal 로 바꿔주고 hidden 처리했던 avaerageLabel 을 보이게 해줌

#30