### PR TITLE
Add StatusDao

### DIFF
--- a/BE/src/main/java/com/codesquad/baseball06/controller/DevController.java
+++ b/BE/src/main/java/com/codesquad/baseball06/controller/DevController.java
@@ -1,5 +1,6 @@
 package com.codesquad.baseball06.controller;
 
+import com.codesquad.baseball06.dto.BattingResultDto;
 import com.codesquad.baseball06.message.DevMessage;
 import com.codesquad.baseball06.dto.ApiResponse;
 import com.codesquad.baseball06.model.entity.Batter;
@@ -55,17 +56,11 @@ public class DevController {
     Batter batter = away.getBatterList().get(0);
     BattingResult battingResult = inningService.doWork(halfInning, pitcher, batter);
 
-    if (battingResult.equals(BattingResult.HIT)) {
-      halfInning.newPlateAppearance();
-    }
-
-    Map<String, Object> resultMap = new HashMap<>();
-    resultMap.put("battingResult", battingResult);
-    resultMap.put("inningStatus", halfInning.getStatus());
-
-    ApiResponse apiResponse = ApiResponse.ok(resultMap);
+    BattingResultDto battingResultDto = BattingResultDto.create(battingResult);
+    ApiResponse apiResponse = ApiResponse.ok(battingResultDto);
 
     if (halfInning.getOut().equals(3)) {
+      //TODO GameService로 해당 로직을 이동한다.
       init();
     }
 

--- a/BE/src/main/java/com/codesquad/baseball06/dto/BattingResultDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/BattingResultDto.java
@@ -1,0 +1,15 @@
+package com.codesquad.baseball06.dto;
+
+import com.codesquad.baseball06.model.type.BattingResult;
+
+public class BattingResultDto {
+  private BattingResult battingResult;
+
+  private BattingResultDto(BattingResult battingResult) {
+    this.battingResult = battingResult;
+  }
+
+  public static BattingResultDto create(BattingResult battingResult) {
+    return new BattingResultDto(battingResult);
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/dto/InningStatusDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/InningStatusDto.java
@@ -1,0 +1,28 @@
+package com.codesquad.baseball06.dto;
+
+import java.util.List;
+import java.util.Map;
+
+public class InningStatusDto {
+  private Map<String, Object> inningStatus;
+  private List<UpdatedBasemanDto> updatedBaseman;
+  private Map<String, Integer> updatedScore;
+  private List<UpdatedPlayerDto> updatedPlayer;
+
+  private InningStatusDto(Map<String, Object> inningStatus,
+      List<UpdatedBasemanDto> updatedBaseman,
+      Map<String, Integer> updatedScore,
+      List<UpdatedPlayerDto> updatedPlayer) {
+    this.inningStatus = inningStatus;
+    this.updatedBaseman = updatedBaseman;
+    this.updatedScore = updatedScore;
+    this.updatedPlayer = updatedPlayer;
+  }
+
+  public static InningStatusDto create(Map<String, Object> inningStatus,
+      List<UpdatedBasemanDto> updatedBaseman,
+      Map<String, Integer> updatedScore,
+      List<UpdatedPlayerDto> updatedPlayer) {
+    return new InningStatusDto(inningStatus, updatedBaseman, updatedScore, updatedPlayer);
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/dto/ScoreDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/ScoreDto.java
@@ -1,0 +1,38 @@
+package com.codesquad.baseball06.dto;
+
+import com.codesquad.baseball06.model.type.InningType;
+
+public class ScoreDto {
+  private Integer homeScore;
+  private Integer awayScore;
+  private Integer inningIndex;
+  private InningType inningType;
+
+  private ScoreDto(Integer homeScore, Integer awayScore, Integer inningIndex,
+      InningType inningType) {
+    this.homeScore = homeScore;
+    this.awayScore = awayScore;
+    this.inningIndex = inningIndex;
+    this.inningType = inningType;
+  }
+
+  public Integer getHomeScore() {
+    return homeScore;
+  }
+
+  public Integer getAwayScore() {
+    return awayScore;
+  }
+
+  public Integer getInningIndex() {
+    return inningIndex;
+  }
+
+  public InningType getInningType() {
+    return inningType;
+  }
+
+  public static ScoreDto create(Integer homeScore, Integer awayScore, Integer inningIndex, InningType inningType) {
+    return new ScoreDto(homeScore, awayScore, inningIndex, inningType);
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedBasemanDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedBasemanDto.java
@@ -20,7 +20,7 @@ public class UpdatedBasemanDto {
     return new UpdatedBasemanDto(firstBase, secondBase, thirdBase);
   }
 
-  static class SpecificBasemanDto {
+  public static class SpecificBasemanDto {
 
     private String name;
     private Long id;

--- a/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedBasemanDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedBasemanDto.java
@@ -1,0 +1,37 @@
+package com.codesquad.baseball06.dto;
+
+public class UpdatedBasemanDto {
+
+  private SpecificBasemanDto firstBase;
+  private SpecificBasemanDto secondBase;
+  private SpecificBasemanDto thirdBase;
+
+  private UpdatedBasemanDto(
+      SpecificBasemanDto firstBase,
+      SpecificBasemanDto secondBase,
+      SpecificBasemanDto thirdBase) {
+    this.firstBase = firstBase;
+    this.secondBase = secondBase;
+    this.thirdBase = thirdBase;
+  }
+
+  public static UpdatedBasemanDto create(SpecificBasemanDto firstBase,
+      SpecificBasemanDto secondBase, SpecificBasemanDto thirdBase) {
+    return new UpdatedBasemanDto(firstBase, secondBase, thirdBase);
+  }
+
+  static class SpecificBasemanDto {
+
+    private String name;
+    private Long id;
+
+    private SpecificBasemanDto(String name, Long id) {
+      this.name = name;
+      this.id = id;
+    }
+
+    public static SpecificBasemanDto create(String name, Long id) {
+      return new SpecificBasemanDto(name, id);
+    }
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedPlayerDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedPlayerDto.java
@@ -1,0 +1,17 @@
+package com.codesquad.baseball06.dto;
+
+import com.codesquad.baseball06.model.type.PlayerType;
+
+public class UpdatedPlayerDto {
+  private Long id;
+  private String name;
+  private PlayerType type;
+  private String teamName;
+
+  public UpdatedPlayerDto(Long id, String name, PlayerType type, String teamName) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+    this.teamName = teamName;
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedPlayerDto.java
+++ b/BE/src/main/java/com/codesquad/baseball06/dto/UpdatedPlayerDto.java
@@ -1,17 +1,42 @@
 package com.codesquad.baseball06.dto;
 
+import com.codesquad.baseball06.model.entity.Batter;
+import com.codesquad.baseball06.model.entity.Pitcher;
 import com.codesquad.baseball06.model.type.PlayerType;
 
 public class UpdatedPlayerDto {
+
   private Long id;
   private String name;
   private PlayerType type;
-  private String teamName;
+  private Long teamId;
+  private Double battingAverage;
+  private Integer batterIndex;
 
-  public UpdatedPlayerDto(Long id, String name, PlayerType type, String teamName) {
+  private UpdatedPlayerDto(Long id, String name, PlayerType type, Long teamId) {
     this.id = id;
     this.name = name;
     this.type = type;
-    this.teamName = teamName;
+    this.teamId = teamId;
+  }
+
+  private UpdatedPlayerDto(Long id, String name, PlayerType type, Long teamId,
+      Double battingAverage, Integer batterIndex) {
+    this.id = id;
+    this.name = name;
+    this.type = type;
+    this.teamId = teamId;
+    this.battingAverage = battingAverage;
+    this.batterIndex = batterIndex;
+  }
+
+  public static UpdatedPlayerDto createUpdatedBatterDto(Batter batter) {
+    return new UpdatedPlayerDto(batter.getId(), batter.getName(), PlayerType.BATTER,
+        batter.getTeamId(), batter.getBattingAverage(), batter.getBatterIndex());
+  }
+
+  public static UpdatedPlayerDto createUpdatedPitcherDto(Pitcher pitcher) {
+    return new UpdatedPlayerDto(pitcher.getId(), pitcher.getName(), PlayerType.PITCHER,
+        pitcher.getTeamId());
   }
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/StatusDao.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/StatusDao.java
@@ -1,9 +1,18 @@
 package com.codesquad.baseball06.model.dao;
 
+import static com.codesquad.baseball06.model.query.InningStatus.BASEMAN_SQL;
+import static com.codesquad.baseball06.model.query.InningStatus.INNING_STATUS;
+import static com.codesquad.baseball06.model.query.Test.BASEMAN_SQL_TEST;
+import static com.codesquad.baseball06.model.query.Test.GAME_SQL_TEST;
+import static com.codesquad.baseball06.model.query.Test.INNINGSTATUS_SQL_TEST;
+import static com.codesquad.baseball06.model.query.Test.SCORE_SQL_TEST;
+
+import com.codesquad.baseball06.dto.UpdatedBasemanDto;
+import com.codesquad.baseball06.model.dao.mapper.BasemanStatusMapper;
 import com.codesquad.baseball06.model.dao.mapper.BatterMapper;
 import com.codesquad.baseball06.model.dao.mapper.PitcherMapper;
-import com.codesquad.baseball06.model.dao.mapper.StatusMapper;
-import java.util.Map;
+import com.codesquad.baseball06.model.dao.mapper.InningStatusMapper;
+import com.codesquad.baseball06.model.entity.InningStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -18,45 +27,41 @@ public class StatusDao {
   private final NamedParameterJdbcTemplate jdbcTemplate;
   private final PitcherMapper pitcherMapper;
   private final BatterMapper batterMapper;
-  private final StatusMapper statusMapper;
+  private final InningStatusMapper inningStatusMapper;
+  private final BasemanStatusMapper basemanStatusMapper;
 
   public StatusDao(NamedParameterJdbcTemplate jdbcTemplate, PitcherMapper pitcherMapper,
       BatterMapper batterMapper,
-      StatusMapper statusMapper) {
+      InningStatusMapper inningStatusMapper,
+      BasemanStatusMapper basemanStatusMapper) {
     this.jdbcTemplate = jdbcTemplate;
     this.pitcherMapper = pitcherMapper;
     this.batterMapper = batterMapper;
-    this.statusMapper = statusMapper;
+    this.inningStatusMapper = inningStatusMapper;
+    this.basemanStatusMapper = basemanStatusMapper;
   }
 
   public void InitForTest() {
 
     //update inningStatus
-    String inningStatusSql = "INSERT INTO inning_status (strike_count, ball_count, out_count) " +
-        "VALUES (:strike_count, :ball_count, :out_count)";
-
     SqlParameterSource countParameters = new MapSqlParameterSource()
         .addValue("strike_count", 1)
         .addValue("ball_count", 2)
-        .addValue("out_count", 1);
+        .addValue("out_count", 1)
+        .addValue("half_inning_id", 1);
 
-    jdbcTemplate.update(inningStatusSql, countParameters);
+    jdbcTemplate.update(INNINGSTATUS_SQL_TEST, countParameters);
 
     //update baseMan
-    String baseManSql = "INSERT INTO base_status (first_base, second_base, third_base) " +
-        "VALUES (:first_base, :second_base, :third_base)";
-
     SqlParameterSource baseParameters = new MapSqlParameterSource()
         .addValue("first_base", 3)
         .addValue("second_base", 4)
-        .addValue("third_base", 5);
+        .addValue("third_base", 5)
+        .addValue("half_inning_id", 1);
 
-    jdbcTemplate.update(baseManSql, baseParameters);
+    jdbcTemplate.update(BASEMAN_SQL_TEST, baseParameters);
 
     //update Score
-    String scoreSql = "INSERT INTO half_inning (game_id, inning_index, type, score, end) " +
-        "VALUES (:id, :game_id, :inning_index, :type, :score, :end)";
-
     SqlParameterSource awayParameters = new MapSqlParameterSource()
         .addValue("game_id", 1)
         .addValue("inning_index", 1)
@@ -64,7 +69,7 @@ public class StatusDao {
         .addValue("score", 2)
         .addValue("end", 1);
 
-    jdbcTemplate.update(scoreSql, awayParameters);
+    jdbcTemplate.update(SCORE_SQL_TEST, awayParameters);
 
     SqlParameterSource homeParameters = new MapSqlParameterSource()
         .addValue("game_id", 1)
@@ -73,19 +78,39 @@ public class StatusDao {
         .addValue("score", 3)
         .addValue("end", 1);
 
-    jdbcTemplate.update(scoreSql, homeParameters);
+    jdbcTemplate.update(SCORE_SQL_TEST, homeParameters);
 
     //update Game
     String gameSql = "INSERT INTO game (home, away, home_user, away_user, end)" +
         "VALUES (:home, :away, :home_user, :away_user, :end)";
 
     SqlParameterSource gameParameters = new MapSqlParameterSource()
-        .addValue("home", null)
-        .addValue("away", null)
+        .addValue("home", 3)
+        .addValue("away", 2)
         .addValue("home_user", "sigrid@naver.com")
         .addValue("away_user", "dan@gmail.com")
         .addValue("end", 0);
 
-    jdbcTemplate.update(gameSql, gameParameters);
+    jdbcTemplate.update(GAME_SQL_TEST, gameParameters);
   }
+
+  public InningStatus getInningStatus() {
+    return jdbcTemplate.query(INNING_STATUS, inningStatusMapper).get(0);
+  }
+
+  public UpdatedBasemanDto getUpdatedBaseman() {
+    return jdbcTemplate.query(BASEMAN_SQL, basemanStatusMapper).get(0);
+  }
+
+//  public boolean getHomeScore() {
+//  }
+//
+//  public boolean getAwayScore() {
+//  }
+//
+//  public boolean getUpdatedPitcher() {
+//  }
+//
+//  public boolean getUpdatedBatter() {
+//  }
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/StatusDao.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/StatusDao.java
@@ -1,0 +1,91 @@
+package com.codesquad.baseball06.model.dao;
+
+import com.codesquad.baseball06.model.dao.mapper.BatterMapper;
+import com.codesquad.baseball06.model.dao.mapper.PitcherMapper;
+import com.codesquad.baseball06.model.dao.mapper.StatusMapper;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class StatusDao {
+
+  private static final Logger log = LoggerFactory.getLogger(PlayerDao.class);
+  private final NamedParameterJdbcTemplate jdbcTemplate;
+  private final PitcherMapper pitcherMapper;
+  private final BatterMapper batterMapper;
+  private final StatusMapper statusMapper;
+
+  public StatusDao(NamedParameterJdbcTemplate jdbcTemplate, PitcherMapper pitcherMapper,
+      BatterMapper batterMapper,
+      StatusMapper statusMapper) {
+    this.jdbcTemplate = jdbcTemplate;
+    this.pitcherMapper = pitcherMapper;
+    this.batterMapper = batterMapper;
+    this.statusMapper = statusMapper;
+  }
+
+  public void InitForTest() {
+
+    //update inningStatus
+    String inningStatusSql = "INSERT INTO inning_status (strike_count, ball_count, out_count) " +
+        "VALUES (:strike_count, :ball_count, :out_count)";
+
+    SqlParameterSource countParameters = new MapSqlParameterSource()
+        .addValue("strike_count", 1)
+        .addValue("ball_count", 2)
+        .addValue("out_count", 1);
+
+    jdbcTemplate.update(inningStatusSql, countParameters);
+
+    //update baseMan
+    String baseManSql = "INSERT INTO base_status (first_base, second_base, third_base) " +
+        "VALUES (:first_base, :second_base, :third_base)";
+
+    SqlParameterSource baseParameters = new MapSqlParameterSource()
+        .addValue("first_base", 3)
+        .addValue("second_base", 4)
+        .addValue("third_base", 5);
+
+    jdbcTemplate.update(baseManSql, baseParameters);
+
+    //update Score
+    String scoreSql = "INSERT INTO half_inning (game_id, inning_index, type, score, end) " +
+        "VALUES (:id, :game_id, :inning_index, :type, :score, :end)";
+
+    SqlParameterSource awayParameters = new MapSqlParameterSource()
+        .addValue("game_id", 1)
+        .addValue("inning_index", 1)
+        .addValue("type", 0)
+        .addValue("score", 2)
+        .addValue("end", 1);
+
+    jdbcTemplate.update(scoreSql, awayParameters);
+
+    SqlParameterSource homeParameters = new MapSqlParameterSource()
+        .addValue("game_id", 1)
+        .addValue("inning_index", 1)
+        .addValue("type", 1)
+        .addValue("score", 3)
+        .addValue("end", 1);
+
+    jdbcTemplate.update(scoreSql, homeParameters);
+
+    //update Game
+    String gameSql = "INSERT INTO game (home, away, home_user, away_user, end)" +
+        "VALUES (:home, :away, :home_user, :away_user, :end)";
+
+    SqlParameterSource gameParameters = new MapSqlParameterSource()
+        .addValue("home", null)
+        .addValue("away", null)
+        .addValue("home_user", "sigrid@naver.com")
+        .addValue("away_user", "dan@gmail.com")
+        .addValue("end", 0);
+
+    jdbcTemplate.update(gameSql, gameParameters);
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/BasemanStatusMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/BasemanStatusMapper.java
@@ -1,0 +1,28 @@
+package com.codesquad.baseball06.model.dao.mapper;
+
+import com.codesquad.baseball06.dto.UpdatedBasemanDto;
+import com.codesquad.baseball06.dto.UpdatedBasemanDto.SpecificBasemanDto;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BasemanStatusMapper implements RowMapper<UpdatedBasemanDto> {
+
+  @Override
+  public UpdatedBasemanDto mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+    List<SpecificBasemanDto> tempList = new ArrayList<>();
+
+    do {
+      SpecificBasemanDto basemanDto = SpecificBasemanDto
+          .create(rs.getString("name"), rs.getLong("id"));
+      tempList.add(basemanDto);
+    } while (rs.next());
+
+    return UpdatedBasemanDto.create(tempList.get(0), tempList.get(1), tempList.get(2));
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/InningIndexTypeMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/InningIndexTypeMapper.java
@@ -1,0 +1,22 @@
+package com.codesquad.baseball06.model.dao.mapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InningIndexTypeMapper implements RowMapper<Map<String, Integer>> {
+
+  @Override
+  public Map<String, Integer> mapRow(ResultSet rs, int rowNum) throws SQLException {
+    HashMap<String, Integer> indexTypeMap = new HashMap<>();
+
+    indexTypeMap.put("inning_index", rs.getInt("inning_index"));
+    indexTypeMap.put("type", rs.getInt("type"));
+
+    return indexTypeMap;
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/InningStatusMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/InningStatusMapper.java
@@ -1,0 +1,24 @@
+package com.codesquad.baseball06.model.dao.mapper;
+
+import com.codesquad.baseball06.model.entity.InningStatus;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InningStatusMapper implements RowMapper<InningStatus> {
+
+  @Override
+  public InningStatus mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+    return InningStatus
+        .create(
+            rs.getLong("id"),
+            rs.getLong("half_inning_id"),
+            rs.getInt("strike_count"),
+            rs.getInt("ball_count"),
+            rs.getInt("out_count")
+        );
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/ScoreMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/ScoreMapper.java
@@ -1,0 +1,26 @@
+package com.codesquad.baseball06.model.dao.mapper;
+
+import com.codesquad.baseball06.dto.ScoreDto;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScoreMapper implements RowMapper<List<Integer>> {
+
+  @Override
+  public List<Integer> mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+    List<Integer> scoreList = new ArrayList<>();
+
+    do {
+      int nowScore = rs.getInt("score");
+      scoreList.add(nowScore);
+    } while (rs.next());
+
+    return scoreList;
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/ScoreMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/ScoreMapper.java
@@ -4,23 +4,29 @@ import com.codesquad.baseball06.dto.ScoreDto;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Component;
 
 @Component
-public class ScoreMapper implements RowMapper<List<Integer>> {
+public class ScoreMapper implements RowMapper<Map<String, Integer>> {
 
   @Override
-  public List<Integer> mapRow(ResultSet rs, int rowNum) throws SQLException {
+  public Map<String, Integer> mapRow(ResultSet rs, int rowNum) throws SQLException {
 
-    List<Integer> scoreList = new ArrayList<>();
+    Map<String, Integer> scoreMap = new HashMap<>();
 
     do {
-      int nowScore = rs.getInt("score");
-      scoreList.add(nowScore);
+      if (rs.getLong("id") == 1) {
+        scoreMap.put("away", rs.getInt("score"));
+      }
+      if (rs.getLong("id") == 2) {
+        scoreMap.put("home", rs.getInt("score"));
+      }
     } while (rs.next());
 
-    return scoreList;
+    return scoreMap;
   }
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/UpdatedBatterMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/UpdatedBatterMapper.java
@@ -1,0 +1,23 @@
+package com.codesquad.baseball06.model.dao.mapper;
+
+import com.codesquad.baseball06.model.entity.Batter;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdatedBatterMapper implements RowMapper<Batter> {
+
+  @Override
+  public Batter mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+    return Batter.create(
+        rs.getLong("id"),
+        rs.getLong("team_id"),
+        rs.getString("name"),
+        rs.getDouble("batting_average"),
+        rs.getInt("batter_index")
+    );
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/UpdatedPitcherMapper.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/dao/mapper/UpdatedPitcherMapper.java
@@ -1,0 +1,21 @@
+package com.codesquad.baseball06.model.dao.mapper;
+
+import com.codesquad.baseball06.model.entity.Pitcher;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class UpdatedPitcherMapper implements RowMapper<Pitcher> {
+
+  @Override
+  public Pitcher mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+    return Pitcher.create(
+        rs.getLong("id"),
+        rs.getLong("team_id"),
+        rs.getString("name")
+    );
+  }
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/entity/Batter.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/entity/Batter.java
@@ -3,10 +3,17 @@ package com.codesquad.baseball06.model.entity;
 public class Batter extends Player {
 
   private final Double battingAverage;
+  private Integer batterIndex;
 
   private Batter(Long id, Long teamId, String name, Double battingAverage) {
     super(id, teamId, name);
     this.battingAverage = battingAverage;
+  }
+
+  private Batter(Long id, Long teamId, String name, Double battingAverage, Integer batterIndex) {
+    super(id, teamId, name);
+    this.battingAverage = battingAverage;
+    this.batterIndex = batterIndex;
   }
 
   private Batter(Long teamId, String name, Double battingAverage) {
@@ -18,6 +25,11 @@ public class Batter extends Player {
     return new Batter(id, teamId, name, battingAverage);
   }
 
+  public static Batter create(Long id, Long teamId, String name, Double battingAverage,
+      Integer batterIndex) {
+    return new Batter(id, teamId, name, battingAverage, batterIndex);
+  }
+
   public static Batter create(Long teamId, String name, Double battingAverage) {
     return new Batter(teamId, name, battingAverage);
   }
@@ -25,5 +37,10 @@ public class Batter extends Player {
   @Override
   public Double getBattingAverage() {
     return battingAverage;
+  }
+
+  @Override
+  public Integer getBatterIndex() {
+    return batterIndex;
   }
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/entity/InningStatus.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/entity/InningStatus.java
@@ -10,17 +10,16 @@ public class InningStatus {
   private Integer ball;
   private Integer out;
 
-  public InningStatus(Long id, Integer strike, Integer ball, Integer out, Long inningId) {
+  public InningStatus(Long id,  Long inningId, Integer strike, Integer ball, Integer out) {
     this.id = id;
+    this.inningId = inningId;
     this.strike = strike;
     this.ball = ball;
     this.out = out;
-    this.inningId = inningId;
   }
 
-  public static InningStatus create(Long id, Integer strike, Integer ball, Integer out,
-      Long inningId) {
-    return new InningStatus(id, strike, ball, out, inningId);
+  public static InningStatus create(Long id, Long inningId, Integer strike, Integer ball, Integer out) {
+    return new InningStatus(id, inningId, strike, ball, out);
   }
 
   public Long getId() {

--- a/BE/src/main/java/com/codesquad/baseball06/model/entity/Pitcher.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/entity/Pitcher.java
@@ -20,9 +20,17 @@ public class Pitcher extends Player {
     return new Pitcher(teamId, name);
   }
 
+  //TODO 조금 더 상속에 대한 개념을 어떻게 적극적으로 사용할 것인가를 질문해보고 싶습니다.. 어려워.
+
   @Override
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public Double getBattingAverage() {
+    return null;
+  }
+
+  @Override
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public Integer getBatterIndex() {
     return null;
   }
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/entity/Player.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/entity/Player.java
@@ -31,4 +31,6 @@ public abstract class Player {
   }
 
   public abstract Double getBattingAverage();
+
+  public abstract Integer getBatterIndex();
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/query/Inning.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/query/Inning.java
@@ -1,0 +1,14 @@
+package com.codesquad.baseball06.model.query;
+
+public class Inning {
+
+  public static String GET_TEAM_SCORES =
+      "SELECT i.id, i.score, IF(i.type, '홈', '어웨이') as type FROM half_inning i\n"
+          + "WHERE i.game_id = :game_id \n"
+          + "GROUP BY i.score, i.type, i.id;";
+
+  public static String GET_INNING_INDEX_AND_TYPE =
+      "SELECT inning_index, type FROM half_inning\n"
+          + "WHERE game_id = :game_id \n"
+          + "ORDER BY id DESC LIMIT 1;";
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/query/InningStatus.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/query/InningStatus.java
@@ -1,0 +1,21 @@
+package com.codesquad.baseball06.model.query;
+
+public class InningStatus {
+
+  public static final String INNING_STATUS =
+      "SELECT i.id, i.strike_count, i.ball_count, i.out_count, i.half_inning_id FROM inning_status i";
+
+  public static final String BASEMAN_SQL = "SELECT p.id, p.team_id, p.type, p.name, p.batting_average,\n"
+      + "(\n"
+      + "\tCASE\n"
+      + "    WHEN p.id = b.first_base THEN '1'\n"
+      + "    WHEN p.id = b.second_base THEN '2'\n"
+      + "    WHEN p.id = b.third_base THEN '3'\n"
+      + "    END\n"
+      + ") AS base_status\n"
+      + "FROM player p, base_status b\n"
+      + "\n"
+      + "WHERE p.id = b.first_base\n"
+      + "OR p.id = b.second_base\n"
+      + "OR p.id = b.third_base;";
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/query/Player.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/query/Player.java
@@ -16,4 +16,24 @@ public class Player {
       "SELECT p.id, p.team_id, p.type, p.name, p.batting_average "
           + "FROM player p "
           + "WHERE p.type = :type";
+  public static final String FIND_CURRENT_BATTER =
+      "SELECT p.id, p.team_id, p.type, p.name, p.batting_average, pa.batter_index \n"
+          + "FROM player p, plate_appearance pa\n"
+          + "WHERE p.id = (SELECT p.batter FROM plate_appearance p, half_inning i\n"
+          + "WHERE i.game_id = 1\n"
+          + "ORDER BY i.id DESC LIMIT 1)\n"
+          + "AND pa.batter = p.id;";
+  public static final String FIND_CURRENT_PITCHER =
+      "SELECT p.id, p.team_id, p.type, p.name FROM player p\n"
+          + "WHERE p.id = (SELECT p.pitcher FROM plate_appearance p, half_inning i\n"
+          + "WHERE i.game_id = 1\n"
+          + "ORDER BY i.id DESC LIMIT 1);";
+  public static final String FIND_CURRENT_PLAYER =
+      "SELECT p.id, p.team_id, p.type, p.name, p.batting_average FROM player p\n"
+          + "WHERE p.id = (SELECT p.pitcher FROM plate_appearance p, half_inning i\n"
+          + "WHERE i.game_id = :game_id\n"
+          + "ORDER BY i.id DESC LIMIT 1)\n"
+          + "OR p.id = (SELECT p.batter FROM plate_appearance p, half_inning i\n"
+          + "WHERE i.game_id = :game_id\n"
+          + "ORDER BY i.id DESC LIMIT 1);";
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/query/Test.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/query/Test.java
@@ -1,0 +1,12 @@
+package com.codesquad.baseball06.model.query;
+
+public class Test {
+  public static String INNINGSTATUS_SQL_TEST = "INSERT INTO inning_status (strike_count, ball_count, out_count, half_inning_id) " +
+      "VALUES (:strike_count, :ball_count, :out_count, :half_inning_id)";
+  public static String BASEMAN_SQL_TEST = "INSERT INTO base_status (first_base, second_base, third_base, half_inning_id) " +
+      "VALUES (:first_base, :second_base, :third_base, :half_inning_id)";
+  public static String SCORE_SQL_TEST = "INSERT INTO half_inning (game_id, inning_index, type, score, end) " +
+      "VALUES (:game_id, :inning_index, :type, :score, :end)";
+  public static String GAME_SQL_TEST = "INSERT INTO game (home, away, home_user, away_user, end)" +
+      "VALUES (:home, :away, :home_user, :away_user, :end)";
+}

--- a/BE/src/main/java/com/codesquad/baseball06/model/query/Test.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/query/Test.java
@@ -1,12 +1,19 @@
 package com.codesquad.baseball06.model.query;
 
 public class Test {
-  public static String INNINGSTATUS_SQL_TEST = "INSERT INTO inning_status (strike_count, ball_count, out_count, half_inning_id) " +
-      "VALUES (:strike_count, :ball_count, :out_count, :half_inning_id)";
-  public static String BASEMAN_SQL_TEST = "INSERT INTO base_status (first_base, second_base, third_base, half_inning_id) " +
-      "VALUES (:first_base, :second_base, :third_base, :half_inning_id)";
-  public static String SCORE_SQL_TEST = "INSERT INTO half_inning (game_id, inning_index, type, score, end) " +
-      "VALUES (:game_id, :inning_index, :type, :score, :end)";
+
+  public static String INNINGSTATUS_SQL_TEST =
+      "INSERT INTO inning_status (strike_count, ball_count, out_count, half_inning_id) " +
+          "VALUES (:strike_count, :ball_count, :out_count, :half_inning_id)";
+  public static String BASEMAN_SQL_TEST =
+      "INSERT INTO base_status (first_base, second_base, third_base, half_inning_id) " +
+          "VALUES (:first_base, :second_base, :third_base, :half_inning_id)";
+  public static String SCORE_SQL_TEST =
+      "INSERT INTO half_inning (game_id, inning_index, type, score, end) " +
+          "VALUES (:game_id, :inning_index, :type, :score, :end)";
   public static String GAME_SQL_TEST = "INSERT INTO game (home, away, home_user, away_user, end)" +
       "VALUES (:home, :away, :home_user, :away_user, :end)";
+  public static String PLATE_SQL_TEST =
+      "INSERT INTO plate_appearance (inning_id, pitcher, batter, batter_index, result, end)"
+          + " VALUES (:inning_id, :pitcher, :batter, :batter_index, :result, :end)";
 }

--- a/BE/src/main/java/com/codesquad/baseball06/model/type/InningType.java
+++ b/BE/src/main/java/com/codesquad/baseball06/model/type/InningType.java
@@ -19,4 +19,13 @@ public enum InningType {
   public String getType() {
     return type;
   }
+
+  public static InningType findType(int code) throws Exception {
+    for (InningType type: InningType.values()) {
+      if (type.code == code) {
+        return type;
+      }
+    }
+    throw new Exception("Enum Not Found.");
+  }
 }

--- a/BE/src/main/java/com/codesquad/baseball06/service/InningService.java
+++ b/BE/src/main/java/com/codesquad/baseball06/service/InningService.java
@@ -27,6 +27,10 @@ public class InningService {
       return BattingResult.END;
     }
 
+    if (plateAppearanceResult.equals(BattingResult.HIT)) {
+      halfInning.newPlateAppearance();
+    }
+
     return plateAppearanceResult;
   }
 }

--- a/BE/src/main/resources/data.sql
+++ b/BE/src/main/resources/data.sql
@@ -22,6 +22,12 @@ INSERT INTO player (team_id, type, name, batting_average)
 VALUES (1, 1, '타자어웨이3', 0.333);
 
 INSERT INTO player (team_id, type, name, batting_average)
+VALUES (1, 1, '타자어웨이4', 0.333);
+
+INSERT INTO player (team_id, type, name, batting_average)
+VALUES (1, 1, '타자어웨이5', 0.333);
+
+INSERT INTO player (team_id, type, name, batting_average)
 VALUES (2, 1, '타자홈1', 0.333);
 
 INSERT INTO player (team_id, type, name, batting_average)
@@ -29,6 +35,12 @@ VALUES (2, 1, '타자홈2', 0.333);
 
 INSERT INTO player (team_id, type, name, batting_average)
 VALUES (2, 1, '타자홈3', 0.333);
+
+INSERT INTO player (team_id, type, name, batting_average)
+VALUES (2, 1, '타자홈4', 0.333);
+
+INSERT INTO player (team_id, type, name, batting_average)
+VALUES (2, 1, '타자홈5', 0.333);
 
 
 INSERT INTO game (away, home, away_user, home_user, end)

--- a/BE/src/main/resources/schema.sql
+++ b/BE/src/main/resources/schema.sql
@@ -76,7 +76,7 @@ CREATE TABLE base_status
     first_base  INT NULL,
     second_base INT NULL,
     third_base  INT NULL,
-    inning_id   INT NOT NULL,
+    half_inning_id   INT NOT NULL,
     PRIMARY KEY (id)
 );
 
@@ -86,6 +86,6 @@ CREATE TABLE inning_status
     strike_count INT NOT NULL,
     ball_count   INT NOT NULL,
     out_count    INT NOT NULL,
-    inning_id    INT NOT NULL,
+    half_inning_id    INT NOT NULL,
     PRIMARY KEY (id)
 );

--- a/BE/src/test/java/com/codesquad/baseball06/model/dao/PlayerDaoTest.java
+++ b/BE/src/test/java/com/codesquad/baseball06/model/dao/PlayerDaoTest.java
@@ -43,7 +43,7 @@ class PlayerDaoTest {
 
   @Test
   void findPitchers() {
-    assertThat(playerDao.findPitcherAndTeamId(3L))
+    assertThat(playerDao.findPitcherAndTeamId(2L))
         .isNotNull()
         .isInstanceOf(ArrayList.class)
         .hasSizeGreaterThan(1);
@@ -51,7 +51,7 @@ class PlayerDaoTest {
 
   @Test
   void findBatters() {
-    assertThat(playerDao.findBatterByTeamId(3L))
+    assertThat(playerDao.findBatterByTeamId(2L))
         .isNotNull()
         .isInstanceOf(ArrayList.class)
         .hasSizeGreaterThan(1);

--- a/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
+++ b/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
@@ -1,8 +1,13 @@
 package com.codesquad.baseball06.model.dao;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.codesquad.baseball06.dto.UpdatedBasemanDto;
 import com.codesquad.baseball06.model.entity.InningStatus;
 import com.codesquad.baseball06.model.type.InningType;
+import java.util.Objects;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -10,50 +15,53 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class StatusDaoTest {
+
   private static final Logger log = LoggerFactory.getLogger(StatusDaoTest.class);
 
   @Autowired
   private StatusDao statusDao;
 
+  @DisplayName("테스트를 수행하기 이전에 테스트에 필요한 정보를 DB에 저장하는 역할을 한다.")
+  @BeforeEach
+  void init() {
+    statusDao.InitForTest();
+  }
+
+  @DisplayName("현재 이닝 정보가 정상적으로 리턴되는지 확인한다.")
   @Test
   void INNING_STATUS가_리턴된다() {
-    statusDao.InitForTest();
     assertThat(statusDao.getInningStatus())
         .isNotNull()
         .isInstanceOf(InningStatus.class);
   }
 
+  @DisplayName("현재 1루수, 2루수, 3루수 정보가 정상적으로 리턴되는지 확인한다.")
   @Test
   void UPDATED_BASEMAN이_리턴된다() {
-    statusDao.InitForTest();
     assertThat(statusDao.getUpdatedBaseman())
         .isNotNull()
         .isInstanceOf(UpdatedBasemanDto.class);
   }
 
+  @DisplayName("Score의 어웨이 팀 점수, 홈 팀 점수, 1회 초 관련 필드가 정상적으로 리턴되는지 확인한다.")
   @ParameterizedTest
   @ValueSource(longs = {1L})
   void UPDATED_SCORE가_리턴된다(Long game_id) throws Exception {
-    statusDao.InitForTest();
     assertThat(statusDao.getScores(game_id).getAwayScore()).isEqualTo(2);
     assertThat(statusDao.getScores(game_id).getHomeScore()).isEqualTo(3);
     assertThat(statusDao.getScores(game_id).getInningIndex()).isEqualTo(1);
     assertThat(statusDao.getScores(game_id).getInningType()).isEqualTo(InningType.LATE);
   }
-//
-//  @Test
-//  void UPDATED_PLAYER가_리턴된다() {
-//    statusDao.InitForTest();
-//    assertThat(statusDao.getUpdatedPitcher())
-//        .isNotNull()
-//        .isInstanceOf(PitcherReturnDto.class);
-//
-//    assertThat(statusDao.getUpdatedBatter())
-//        .isNotNull()
-//        .isInstanceOf(BatterReturnDto.class);
-//  }
+
+  @DisplayName("Player가 정상적으로 ArrayList에 담겨 리턴되는 지 확인한다.")
+  @Test
+  void UPDATED_PLAYER가_리턴된다() {
+    assertThat(statusDao.getUpdatedPlayers(1L))
+        .isNotNull();
+    assertThat(statusDao.getUpdatedPlayers(1L)
+        .stream().allMatch(Objects::nonNull)).isTrue();
+  }
 }

--- a/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
+++ b/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
@@ -4,6 +4,7 @@ import com.codesquad.baseball06.dto.BatterReturnDto;
 import com.codesquad.baseball06.dto.InningStatusDto;
 import com.codesquad.baseball06.dto.PitcherReturnDto;
 import com.codesquad.baseball06.dto.UpdatedBasemanDto;
+import com.codesquad.baseball06.model.entity.InningStatus;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,7 +25,7 @@ class StatusDaoTest {
     statusDao.InitForTest();
     assertThat(statusDao.getInningStatus())
         .isNotNull()
-        .isInstanceOf(InningStatusDto.class);
+        .isInstanceOf(InningStatus.class);
   }
 
   @Test
@@ -35,24 +36,24 @@ class StatusDaoTest {
         .isInstanceOf(UpdatedBasemanDto.class);
   }
 
-  @Test
-  void UPDATED_SCORE가_리턴된다() {
-    statusDao.InitForTest();
-    assertThat(statusDao.getHomeScore())
-        .isNotNull();
-    assertThat(statusDao.getAwayScore())
-        .isNotNull();
-  }
-
-  @Test
-  void UPDATED_PLAYER가_리턴된다() {
-    statusDao.InitForTest();
-    assertThat(statusDao.getUpdatedPitcher())
-        .isNotNull()
-        .isInstanceOf(PitcherReturnDto.class);
-
-    assertThat(statusDao.getUpdatedBatter())
-        .isNotNull()
-        .isInstanceOf(BatterReturnDto.class);
-  }
+//  @Test
+//  void UPDATED_SCORE가_리턴된다() {
+//    statusDao.InitForTest();
+//    assertThat(statusDao.getHomeScore())
+//        .isNotNull();
+//    assertThat(statusDao.getAwayScore())
+//        .isNotNull();
+//  }
+//
+//  @Test
+//  void UPDATED_PLAYER가_리턴된다() {
+//    statusDao.InitForTest();
+//    assertThat(statusDao.getUpdatedPitcher())
+//        .isNotNull()
+//        .isInstanceOf(PitcherReturnDto.class);
+//
+//    assertThat(statusDao.getUpdatedBatter())
+//        .isNotNull()
+//        .isInstanceOf(BatterReturnDto.class);
+//  }
 }

--- a/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
+++ b/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
@@ -1,17 +1,16 @@
 package com.codesquad.baseball06.model.dao;
 
-import com.codesquad.baseball06.dto.BatterReturnDto;
-import com.codesquad.baseball06.dto.InningStatusDto;
-import com.codesquad.baseball06.dto.PitcherReturnDto;
 import com.codesquad.baseball06.dto.UpdatedBasemanDto;
 import com.codesquad.baseball06.model.entity.InningStatus;
+import com.codesquad.baseball06.model.type.InningType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 @SpringBootTest
 class StatusDaoTest {
@@ -36,14 +35,15 @@ class StatusDaoTest {
         .isInstanceOf(UpdatedBasemanDto.class);
   }
 
-//  @Test
-//  void UPDATED_SCORE가_리턴된다() {
-//    statusDao.InitForTest();
-//    assertThat(statusDao.getHomeScore())
-//        .isNotNull();
-//    assertThat(statusDao.getAwayScore())
-//        .isNotNull();
-//  }
+  @ParameterizedTest
+  @ValueSource(longs = {1L})
+  void UPDATED_SCORE가_리턴된다(Long game_id) throws Exception {
+    statusDao.InitForTest();
+    assertThat(statusDao.getScores(game_id).getAwayScore()).isEqualTo(2);
+    assertThat(statusDao.getScores(game_id).getHomeScore()).isEqualTo(3);
+    assertThat(statusDao.getScores(game_id).getInningIndex()).isEqualTo(1);
+    assertThat(statusDao.getScores(game_id).getInningType()).isEqualTo(InningType.LATE);
+  }
 //
 //  @Test
 //  void UPDATED_PLAYER가_리턴된다() {

--- a/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
+++ b/BE/src/test/java/com/codesquad/baseball06/model/dao/StatusDaoTest.java
@@ -1,0 +1,58 @@
+package com.codesquad.baseball06.model.dao;
+
+import com.codesquad.baseball06.dto.BatterReturnDto;
+import com.codesquad.baseball06.dto.InningStatusDto;
+import com.codesquad.baseball06.dto.PitcherReturnDto;
+import com.codesquad.baseball06.dto.UpdatedBasemanDto;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+@SpringBootTest
+class StatusDaoTest {
+  private static final Logger log = LoggerFactory.getLogger(StatusDaoTest.class);
+
+  @Autowired
+  private StatusDao statusDao;
+
+  @Test
+  void INNING_STATUS가_리턴된다() {
+    statusDao.InitForTest();
+    assertThat(statusDao.getInningStatus())
+        .isNotNull()
+        .isInstanceOf(InningStatusDto.class);
+  }
+
+  @Test
+  void UPDATED_BASEMAN이_리턴된다() {
+    statusDao.InitForTest();
+    assertThat(statusDao.getUpdatedBaseman())
+        .isNotNull()
+        .isInstanceOf(UpdatedBasemanDto.class);
+  }
+
+  @Test
+  void UPDATED_SCORE가_리턴된다() {
+    statusDao.InitForTest();
+    assertThat(statusDao.getHomeScore())
+        .isNotNull();
+    assertThat(statusDao.getAwayScore())
+        .isNotNull();
+  }
+
+  @Test
+  void UPDATED_PLAYER가_리턴된다() {
+    statusDao.InitForTest();
+    assertThat(statusDao.getUpdatedPitcher())
+        .isNotNull()
+        .isInstanceOf(PitcherReturnDto.class);
+
+    assertThat(statusDao.getUpdatedBatter())
+        .isNotNull()
+        .isInstanceOf(BatterReturnDto.class);
+  }
+}


### PR DESCRIPTION
## DONE
* [ ] 현재 이닝정보를 리턴하는 테스트와 Dao 그리고 Mapper 구현
* [ ] 현재 루수 정보를 리턴하는 테스트와 Dao 그리고 Mapper 구현
* [ ] 현재 점수 정보를 리턴하는 테스트와 Dao 그리고 Mapper 구현
* [ ] 현재 선수 정보를 리턴하는 테스트와 Dao 그리고 Mapper 구현
* [ ] 위의 정보를 리턴하기 위해 필요한 Dto 구현

## TODO
* [ ] 실제로 Web 레이어 상에서 리턴하기 위한 서비스와 컨트롤러 구현 (오늘 페어시간에 같이하길 희망함)

## Remark
* 제가 따로 듣고 있는 NextStep 강의에서 JUnit5 관련 피드백을 받았는데요. 이를 테스트에 적용해보고자 했습니다.
	* 키워드: ```@ParameterizedTest```, ```@DisplayName``` 를 사용한 테스트 중복제거 및 명시화
* 현재 타자 정보에서 타자의 순서를 리턴하기 위해 ```batter_index```를 Player를 상속하는 Pitcher와 ```Batter``` 모두에게 추가해주었습니다. 이를 어떻게 리팩토링해서 Pitcher와 Batter를 명확히 구분할 수 있을 지 고민해보아야 할 것 같습니다.